### PR TITLE
LCD example pin numbers

### DIFF
--- a/examples/lcdthermocouple/LCDthermocouple.pde
+++ b/examples/lcdthermocouple/LCDthermocouple.pde
@@ -17,9 +17,9 @@
 #include "Adafruit_MAX31855.h"
 #include <LiquidCrystal.h>
 
-int thermoCLK = 3;
+int thermoDO = 3;
 int thermoCS = 4;
-int thermoDO = 5;
+int thermoCLK = 5;
 
 // Initialize the Thermocouple
 Adafruit_MAX31855 thermocouple(thermoCLK, thermoCS, thermoDO);


### PR DESCRIPTION
Changed the LCD example to match the same pin numbers as the serial
example, so that people who just bought the sensor can easily switch
from one sketch to another without changing the wiring
