### PR TITLE
added hardware SPI support

### DIFF
--- a/Adafruit_MAX31855.h
+++ b/Adafruit_MAX31855.h
@@ -24,6 +24,7 @@
 class Adafruit_MAX31855 {
  public:
   Adafruit_MAX31855(int8_t SCLK, int8_t CS, int8_t MISO);
+  Adafruit_MAX31855(int8_t CS);
 
   double readInternal(void);
   double readCelsius(void);
@@ -31,6 +32,7 @@ class Adafruit_MAX31855 {
   uint8_t readError();
 
  private:
-  int8_t sclk, miso, cs;
+  int8_t sclk, miso, cs, hSPI;
   uint32_t spiread32(void);
+  uint32_t hspiread32(void);
 };


### PR DESCRIPTION
Bit banging was eating up too many CPU cycles so I added hardware SPI support via a constructor that only accepts a chip select pin (the other pins are fixed in hardware SPI). It works as is, but could maybe use an example. If you're interested in accepting this change let me know and I'll add an example or any other small tweaks you'd like.
