### PR TITLE
Added ifndef blocks to prevent compiler errors

### DIFF
--- a/Adafruit_MAX31855.h
+++ b/Adafruit_MAX31855.h
@@ -14,6 +14,8 @@
   BSD license, all text above must be included in any redistribution
  ****************************************************/
 
+#ifndef ADAFRUIT_MAX31855_H
+#define ADAFRUIT_MAX31855_H
 
 #if (ARDUINO >= 100)
  #include "Arduino.h"
@@ -34,3 +36,5 @@ class Adafruit_MAX31855 {
   int8_t sclk, miso, cs;
   uint32_t spiread32(void);
 };
+
+#endif


### PR DESCRIPTION
When multiple interdependent files include the library, a "error: redefinition of 'class Adafruit_MAX31855'" is thrown by the compiler. Adding these pre-processor directives prevents this error and results in the code being included only once.
