### PR TITLE
Fix mask for sign-extending celsius value

### DIFF
--- a/Adafruit_MAX31855.cpp
+++ b/Adafruit_MAX31855.cpp
@@ -99,7 +99,7 @@ double Adafruit_MAX31855::readCelsius(void) {
 
   if (v & 0x80000000) {
     // Negative value, drop the lower 18 bits and explicitly extend sign bits.
-    v = 0xFFFFC000 | ((v >> 18) & 0x00003FFFF);
+    v = 0xFFFFC000 | ((v >> 18) & 0x000003FFF);
   }
   else {
     // Positive value, just drop the lower 18 bits.


### PR DESCRIPTION
The result doesn't change, but the code is more correct this way (18 + 14 = 32 bits).
