### PR TITLE
Remove unneeded delay in hspiread32

### DIFF
--- a/Adafruit_MAX31855.cpp
+++ b/Adafruit_MAX31855.cpp
@@ -170,7 +170,6 @@ uint32_t Adafruit_MAX31855::hspiread32(void) {
   } buffer;
   
   digitalWrite(cs, LOW);
-  delay(1);
   
   for (i=3;i>=0;i--) {
     buffer.bytes[i] = SPI.transfer(0x00);


### PR DESCRIPTION
This reduces the time for a typical readCelcius call from over a
millisecond to a couple of dozen microseconds, making the library much
more suited for use in timing-critical applications and control loops.

This delay was present between the lowering of the chip select line and
the first transfer. Looking at the MAX31855 datashee, it shows that the
time needed between the chip select drop and the first clock rise (tCSS)
is 100ns. This delay will be present due to function call overheads many
times over, so there is no need for an explicit delay.

Similar delays exist for software SPI, which are probably also not
needed, but I did not test this.
