### PR TITLE
Optimisation

### DIFF
--- a/Adafruit_MAX31855.cpp
+++ b/Adafruit_MAX31855.cpp
@@ -92,7 +92,6 @@ double Adafruit_MAX31855::readCelsius(void) {
     internal *= -1;
   Serial.print("\tInternal Temp: "); Serial.println(internal);
   */
-
   if (v & 0x7) {
     // uh oh, a serious problem!
     return NAN; 

--- a/Adafruit_MAX31855.h
+++ b/Adafruit_MAX31855.h
@@ -23,6 +23,11 @@
  #include "WProgram.h"
 #endif
 
+typedef struct max31855readings {
+  double internal;
+  double celsius;
+};
+
 class Adafruit_MAX31855 {
  public:
   Adafruit_MAX31855(int8_t _sclk, int8_t _cs, int8_t _miso);
@@ -32,6 +37,7 @@ class Adafruit_MAX31855 {
   double readInternal(void);
   double readCelsius(void);
   double readFarenheit(void);
+  max31855readings readTemperatures(void);
   uint8_t readError();
 
  private:
@@ -39,6 +45,10 @@ class Adafruit_MAX31855 {
 
   int8_t sclk, miso, cs;
   uint32_t spiread32(void);
+
+  double processInternal(uint32_t);
+  double processCelsius(int32_t);
+
 };
 
 #endif

--- a/keywords.txt
+++ b/keywords.txt
@@ -6,7 +6,7 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-max6675	KEYWORD1
+max31855readings	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -14,8 +14,10 @@ max6675	KEYWORD1
 
 readCelsius	KEYWORD2
 readFarenheit	KEYWORD2
+readInternal	KEYWORD2
+readTemperatures	KEYWORD2
+readError()	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
-


### PR DESCRIPTION
Created a new readTemperatures() function which makes a single call to spiread32() then processes the response to extract both hot and cold junction temperatures into a struct, which is then returned. This has had a dramatic impact on performance, using the spiread32() for software SPI was taking approximately 0.2 seconds to call both readInternal() then readCelsius() in order to linearise the temperature.

I've modified the header and code to include the new function, and associated definition. I've also split the readInternal() and readCelsius() functions to separate the processing logic to ensure backwards compatibility. Therefore the processInternal() and processCelsius() functions continue to be the single location for processing.

Based on the pull request from @matthijskooijman I also removed the delay() calls from the software SPI half of spiread32().

The overall result of these changes is that the probe can be read, including linearisation, in less than 12,000 microseconds (0.012 seconds) almost a 17x increase in application level performance.

I have tested this on an Adafruit Feather Huzzah ESP8266 (Product ID: 2821). I do not have any other boards to test this on I'm afraid. My tests included the new function, and the existing functions. I have not observed any impact, I therefore believe these changes are backwards compatible but also provide a slightly simpler interface (although if the library included the linearisation code, I suppose readTemperature() would be a logical development to simply return the temperature itself). The complete removal of the delay() could cause problems, although at the 100 nano second timing level (0.1 microsecond) this isn't likely. I have not tested this on a hardware SPI implementation, merely removed the delay() from that half of the code as per @matthijskooijman's pull request.

I also took a moment to refresh the keywords.txt file to include the new functions, but also a couple of missing ones.

Thanks for your time.

Robert.
