### PR TITLE
fixed typo Farenheit -> Fahrenheit, reduced Fahrenheit computation by…

### DIFF
--- a/Adafruit_MAX31855.cpp
+++ b/Adafruit_MAX31855.cpp
@@ -119,10 +119,9 @@ uint8_t Adafruit_MAX31855::readError() {
   return spiread32() & 0x7;
 }
 
-double Adafruit_MAX31855::readFarenheit(void) {
+double Adafruit_MAX31855::readFahrenheit(void) {
   float f = readCelsius();
-  f *= 9.0;
-  f /= 5.0;
+  f *= 1.8;
   f += 32;
   return f;
 }

--- a/Adafruit_MAX31855.h
+++ b/Adafruit_MAX31855.h
@@ -31,7 +31,7 @@ class Adafruit_MAX31855 {
   void begin(void);
   double readInternal(void);
   double readCelsius(void);
-  double readFarenheit(void);
+  double readFahrenheit(void);
   uint8_t readError();
 
  private:

--- a/examples/serialthermocouple/serialthermocouple.ino
+++ b/examples/serialthermocouple/serialthermocouple.ino
@@ -57,7 +57,7 @@ void loop() {
      Serial.println(c);
    }
    //Serial.print("F = ");
-   //Serial.println(thermocouple.readFarenheit());
+   //Serial.println(thermocouple.readFahrenheit());
  
    delay(1000);
 }

--- a/keywords.txt
+++ b/keywords.txt
@@ -13,7 +13,7 @@ max6675	KEYWORD1
 #######################################
 
 readCelsius	KEYWORD2
-readFarenheit	KEYWORD2
+readFahrenheit	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit MAX31855 library
-version=1.0.3
+version=1.0.4
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Library for the Adafruit Thermocouple breakout with MAX31855K


### PR DESCRIPTION
… one step (* 1.8 is "_quicker_" than * 9 / 5)

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.** 
fixed typo Farenheit -> Fahrenheit, reduced Fahrenheit computation by one step (* 1.8 is "_quicker_" than * 9 / 5)

- **Describe any known limitations with your change.**
Since the function is renamed, any code that relies on the typo in place needs to be fixed as well.

- **Please run any tests or examples that can exercise your modified code.**
Examples compile fine.
