### PR TITLE
Thermocouple fault masking for dodgy breakout modules

### DIFF
--- a/Adafruit_MAX31855.cpp
+++ b/Adafruit_MAX31855.cpp
@@ -93,6 +93,10 @@ double Adafruit_MAX31855::readCelsius(void) {
   Serial.print("\tInternal Temp: "); Serial.println(internal);
   */
 
+  if (mask) {
+    v &= mask;
+  }
+
   if (v & 0x7) {
     // uh oh, a serious problem!
     return NAN; 
@@ -175,4 +179,9 @@ uint32_t Adafruit_MAX31855::spiread32(void) {
   digitalWrite(cs, HIGH);
   //Serial.println(d, HEX);
   return d;
+}
+
+
+void Adafruit_MAX31855::setErrorMask(uint32_t _mask) {
+  mask = ~(_mask & 0x7);
 }

--- a/Adafruit_MAX31855.h
+++ b/Adafruit_MAX31855.h
@@ -23,6 +23,10 @@
  #include "WProgram.h"
 #endif
 
+#define MAX31855_ERR_OC  0x1
+#define MAX31855_ERR_GND 0x2
+#define MAX31855_ERR_VCC 0x4
+
 class Adafruit_MAX31855 {
  public:
   Adafruit_MAX31855(int8_t _sclk, int8_t _cs, int8_t _miso);
@@ -33,12 +37,13 @@ class Adafruit_MAX31855 {
   double readCelsius(void);
   double readFarenheit(void);
   uint8_t readError();
+  void setErrorMask(uint32_t);
 
  private:
   boolean initialized;
-
   int8_t sclk, miso, cs;
   uint32_t spiread32(void);
+  uint32_t mask;
 };
 
 #endif

--- a/examples/serialthermocouple/serialthermocouple.ino
+++ b/examples/serialthermocouple/serialthermocouple.ino
@@ -51,7 +51,20 @@ void loop() {
 
    double c = thermocouple.readCelsius();
    if (isnan(c)) {
-     Serial.println("Something wrong with thermocouple!");
+     uint8_t e = thermocouple.readError();
+     if (e) {
+       Serial.print(F("Thermocouple error(s): "));
+       if (e & MAX31855_ERR_OC) {
+         Serial.print(F("[open circuit] "));
+       }
+       if (e & MAX31855_ERR_GND) {
+         Serial.print(F("[short to GND] "));
+       }
+       if (e & MAX31855_ERR_VCC) {
+         Serial.print(F("[short to VCC] "));
+       }
+       Serial.println();
+     }
    } else {
      Serial.print("C = "); 
      Serial.println(c);

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit MAX31855 library
-version=1.0.3
+version=1.0.4
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Library for the Adafruit Thermocouple breakout with MAX31855K


### PR DESCRIPTION
**Purpose of Changes:**
 - Some cheap generic MAX31855 breakout modules report a thermocouple ground fault, even with no thermocouple connected. 
I have recently received a number of these modules, all with the thermocouple terminal marked "Red -" tied directly to GND. 
Ignoring that specific fault enables these modules to work correctly with the Adafruit-MAX31855 library.


**Scope of Changes:**
 - Adds detailed information about thermocouple faults to the example serial sketch
 - Adds ability to disable specific thermocouple faults

 **Limitations:**
  None apparent 
  
**New functionality:**
 - This PR adds a `setErrorMask` function, which can be called to mask/unmask any combination of the three thermocouple error conditions. 

These are defined as:
**`MAX31855_ERR_OC`**  Thermocouple open circuit
**`MAX31855_ERR_GND`** Thermocouple short to GND
**`MAX31855_ERR_VCC`** Thermocouple short to VCC


**Usage examples:**

	// mask short circuit to GND and/or VCC faults
	Adafruit_MAX31855::setErrorMask(MAX31855_ERR_GND + MAX31855_ERR_VCC);
  
	// mask open circuit faults (probably not a great idea, but included for completeness...)
	Adafruit_MAX31855::setErrorMask(MAX31855_ERR_OC);
	
	// unmask all faults
	Adafruit_MAX31855::setErrorMask(0);
	
**Testing:**
- Output from generic breakout module with apparent fault, using existing serialthermocouple.ino sketch:

> ```
> MAX31855 test
> Internal Temp = 32.75
> Something wrong with thermocouple!
> ```

- same module, with updated serialthermocouple.ino sketch:

> ```
> MAX31855 test
> Internal Temp = 32.94
> Thermocouple error(s): [short to GND] 
> ```

- same, but with thermocouple disconnected:

> ```
> MAX31855 test
> Internal Temp = 32.69
> Thermocouple error(s): [open circuit] [short to GND] 
> ```

- modify serialthermocouple.ino, add following line to setup():
  **`thermocouple.setErrorMask(MAX31855_ERR_GND);`** 
(and re-connect tc)

> ```
> MAX31855 test
> Internal Temp = 32.75
> C = 31.50
> ```