### PR TITLE
ESP32 two HW SPI support

### DIFF
--- a/Adafruit_MAX31855.cpp
+++ b/Adafruit_MAX31855.cpp
@@ -40,23 +40,17 @@ Adafruit_MAX31855::Adafruit_MAX31855(int8_t _cs) {
   initialized = false;
 }
 
-void Adafruit_MAX31855::begin(void) {
+void Adafruit_MAX31855::begin(SPIClass *SPI_Pointer) {
   //define pin modes
   pinMode(cs, OUTPUT);
   digitalWrite(cs, HIGH);
 
-  MAXSPI = new SPIClass();
+  MAXSPI = SPI_Pointer;
 
   if (sclk == -1) {
     // hardware SPI
     //start and configure hardware SPI
-#ifdef ESP32	// if we have ESP32 - where we have 2 HW SPIs
-    if(cs==5) MAXSPI->begin(18, 19, 23, 5);	// VSPI - pins SCLK = 18, MISO = 19, MOSI = 23, SS = 5
-    else MAXSPI->begin(14, 12, 13, 15);		// HSPI - pins SCLK = 14, MISO = 12, MOSI = 13, SS = 15 - HSPI is default SPI on ESP32
-    pinMode(cs, OUTPUT);
-#elif		// everything else
     MAXSPI->begin();
-#endif
   } else {
     pinMode(sclk, OUTPUT);
     pinMode(miso, INPUT);

--- a/Adafruit_MAX31855.cpp
+++ b/Adafruit_MAX31855.cpp
@@ -53,9 +53,9 @@ void Adafruit_MAX31855::begin(void) {
 #ifdef ESP32	// if we have ESP32 - where we have 2 HW SPIs
     if(cs==5) MAXSPI->begin(18, 19, 23, 5);	// VSPI - pins SCLK = 18, MISO = 19, MOSI = 23, SS = 5
     else MAXSPI->begin(14, 12, 13, 15);		// HSPI - pins SCLK = 14, MISO = 12, MOSI = 13, SS = 15 - HSPI is default SPI on ESP32
+    pinMode(cs, OUTPUT);
 #elif		// everything else
     MAXSPI->begin();
-    pinMode(cs, OUTPUT);
 #endif
   } else {
     pinMode(sclk, OUTPUT);

--- a/Adafruit_MAX31855.h
+++ b/Adafruit_MAX31855.h
@@ -36,12 +36,6 @@ class Adafruit_MAX31855 {
   double readFarenheit(void);
   uint8_t readError();
 
-  // advanced functions
-/*  uint32_t readRaw(void);
-  double   decodeCelsius(uint32_t rawData);
-  double   decodeInternal(uint32_t rawData);
-  double   linearizeCelcius(double internalTemp, double rawTemp);
-*/
  private:
   boolean initialized;
 

--- a/Adafruit_MAX31855.h
+++ b/Adafruit_MAX31855.h
@@ -1,16 +1,16 @@
-/*************************************************** 
+/***************************************************
   This is a library for the Adafruit Thermocouple Sensor w/MAX31855K
 
   Designed specifically to work with the Adafruit Thermocouple Sensor
   ----> https://www.adafruit.com/products/269
 
-  These displays use SPI to communicate, 3 pins are required to  
+  These displays use SPI to communicate, 3 pins are required to
   interface
-  Adafruit invests time and resources providing this open source code, 
-  please support Adafruit and open-source hardware by purchasing 
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
   products from Adafruit!
 
-  Written by Limor Fried/Ladyada for Adafruit Industries.  
+  Written by Limor Fried/Ladyada for Adafruit Industries.
   BSD license, all text above must be included in any redistribution
  ****************************************************/
 
@@ -30,7 +30,7 @@ class Adafruit_MAX31855 {
   Adafruit_MAX31855(int8_t _sclk, int8_t _cs, int8_t _miso);
   Adafruit_MAX31855(int8_t _cs);
 
-  void begin(void);
+  void begin(SPIClass *SPI_Pointer = &SPI);
   double readInternal(void);
   double readCelsius(void);
   double readFarenheit(void);
@@ -38,9 +38,9 @@ class Adafruit_MAX31855 {
 
  private:
   boolean initialized;
+  SPIClass * MAXSPI = NULL;
 
   int8_t sclk, miso, cs;
-  SPIClass * MAXSPI = NULL;
   uint32_t spiread32(void);
 };
 

--- a/Adafruit_MAX31855.h
+++ b/Adafruit_MAX31855.h
@@ -17,6 +17,8 @@
 #ifndef ADAFRUIT_MAX31855_H
 #define ADAFRUIT_MAX31855_H
 
+#include <SPI.h>
+
 #if (ARDUINO >= 100)
  #include "Arduino.h"
 #else
@@ -34,10 +36,17 @@ class Adafruit_MAX31855 {
   double readFarenheit(void);
   uint8_t readError();
 
+  // advanced functions
+/*  uint32_t readRaw(void);
+  double   decodeCelsius(uint32_t rawData);
+  double   decodeInternal(uint32_t rawData);
+  double   linearizeCelcius(double internalTemp, double rawTemp);
+*/
  private:
   boolean initialized;
 
   int8_t sclk, miso, cs;
+  SPIClass * MAXSPI = NULL;
   uint32_t spiread32(void);
 };
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Atmega328 @ 12MHz  |      X       |             |            | For LCD example h
 Atmega32u4 @ 16MHz |      X       |             |            | 
 Atmega32u4 @ 8MHz  |      X       |             |            | 
 ESP8266            |      X       |             |            | 
+ESP32              |      X       |             |            | Can use both SPI HSPI/VSPI
 Atmega2560 @ 16MHz |      X       |             |            | 
 ATSAM3X8E          |      X       |             |            | 
 ATSAM21D           |      X       |             |            | 
@@ -23,6 +24,7 @@ STM32F2            |             |             |     X       |
   * ATmega32u4 @ 16MHz : Arduino Leonardo, Arduino Micro, Arduino Yun, Teensy 2.0
   * ATmega32u4 @ 8MHz : Adafruit Flora, Bluefruit Micro
   * ESP8266 : Adafruit Huzzah
+  * ESP32 : ESP32-Wrover-B Espressif
   * ATmega2560 @ 16MHz : Arduino Mega
   * ATSAM3X8E : Arduino Due
   * ATSAM21D : Arduino Zero, M0 Pro

--- a/examples/serialthermocouple/serialthermocouple.ino
+++ b/examples/serialthermocouple/serialthermocouple.ino
@@ -34,10 +34,18 @@ Adafruit_MAX31855 thermocouple(MAXCLK, MAXCS, MAXDO);
 //#define MAXCS   10
 //Adafruit_MAX31855 thermocouple(MAXCS);
 
+// If you want to use other HW SPI then default, you can pass pointer to begin() function. On ESP32 it could look like this
+//#define MAXCS	15				// this is CS for HSPI, for VSPI its 5
+//Adafruit_MAX31855 thermocouple(MAXCS);
+//SPIClass *ESP32_HSPI = new SPIClass(HSPI);	// create new SPI object
+// Then you need to pass pointer to this object with begin() in setup below
+
 void setup() {
   Serial.begin(9600);
  
   while (!Serial) delay(1); // wait for Serial on Leonardo/Zero, etc
+
+//thermocouple.begin(ESP32_HSPI);		// pass pointer to HSPI on ESP32
 
   Serial.println("MAX31855 test");
   // wait for MAX chip to stabilize
@@ -45,7 +53,7 @@ void setup() {
 }
 
 void loop() {
-  // basic readout test, just print the current temp
+   // basic readout test, just print the current temp
    Serial.print("Internal Temp = ");
    Serial.println(thermocouple.readInternal());
 


### PR DESCRIPTION
This is quick change allowing to use two HW SPI interfaces on ESP32 boards. It should not brake anything for other boards.

I've defined pointer SPIClass * MAXSPI in Adafruit_MAX31855 class. Then used it for creating proper SPI. This cannot be global if we have more SPIs available.
Then if it's ESP32 board and if user defines CS=5 we switch to VSPI
```
#ifdef ESP32    // if we have ESP32 - where we have 2 HW SPIs
    if(cs==5) MAXSPI->begin(18, 19, 23, 5);     // VSPI - pins SCLK = 18, MISO = 19, MOSI = 23, SS = 5
    else MAXSPI->begin(14, 12, 13, 15);         // HSPI - pins SCLK = 14, MISO = 12, MOSI = 13, SS = 15 - HSPI is default SPI on ESP32
    pinMode(cs, OUTPUT);
#elif           // everything else

```
