### PR TITLE
Fix "warning: passing NULL to non-pointer argument ..."

### DIFF
--- a/Adafruit_MAX31855.cpp
+++ b/Adafruit_MAX31855.cpp
@@ -51,11 +51,9 @@
     @param _miso The pin to use for SPI Master In Slave Out.
 */
 /**************************************************************************/
-Adafruit_MAX31855::Adafruit_MAX31855(int8_t _sclk, int8_t _cs, int8_t _miso) {
-  spi_dev = Adafruit_SPIDevice(_cs, _sclk, _miso, -1, 1000000);
-
-  initialized = false;
-}
+Adafruit_MAX31855::Adafruit_MAX31855(int8_t _sclk, int8_t _cs, int8_t _miso) :
+  spi_dev(_cs, _sclk, _miso, -1, 1000000)
+{}
 
 /**************************************************************************/
 /*!
@@ -64,11 +62,9 @@ Adafruit_MAX31855::Adafruit_MAX31855(int8_t _sclk, int8_t _cs, int8_t _miso) {
     @param _cs The pin to use for SPI Chip Select.
 */
 /**************************************************************************/
-Adafruit_MAX31855::Adafruit_MAX31855(int8_t _cs) {
-  spi_dev = Adafruit_SPIDevice(_cs, 1000000);
-
-  initialized = false;
-}
+Adafruit_MAX31855::Adafruit_MAX31855(int8_t _cs) :
+  spi_dev(_cs, 1000000)
+{}
 
 /**************************************************************************/
 /*!

--- a/Adafruit_MAX31855.cpp
+++ b/Adafruit_MAX31855.cpp
@@ -51,9 +51,8 @@
     @param _miso The pin to use for SPI Master In Slave Out.
 */
 /**************************************************************************/
-Adafruit_MAX31855::Adafruit_MAX31855(int8_t _sclk, int8_t _cs, int8_t _miso) :
-  spi_dev(_cs, _sclk, _miso, -1, 1000000)
-{}
+Adafruit_MAX31855::Adafruit_MAX31855(int8_t _sclk, int8_t _cs, int8_t _miso)
+    : spi_dev(_cs, _sclk, _miso, -1, 1000000) {}
 
 /**************************************************************************/
 /*!
@@ -62,9 +61,7 @@ Adafruit_MAX31855::Adafruit_MAX31855(int8_t _sclk, int8_t _cs, int8_t _miso) :
     @param _cs The pin to use for SPI Chip Select.
 */
 /**************************************************************************/
-Adafruit_MAX31855::Adafruit_MAX31855(int8_t _cs) :
-  spi_dev(_cs, 1000000)
-{}
+Adafruit_MAX31855::Adafruit_MAX31855(int8_t _cs) : spi_dev(_cs, 1000000) {}
 
 /**************************************************************************/
 /*!

--- a/Adafruit_MAX31855.cpp
+++ b/Adafruit_MAX31855.cpp
@@ -187,7 +187,6 @@ double Adafruit_MAX31855::readFahrenheit(void) {
 */
 /**************************************************************************/
 uint32_t Adafruit_MAX31855::spiread32(void) {
-  int i;
   uint32_t d = 0;
   uint8_t buf[4];
 

--- a/Adafruit_MAX31855.h
+++ b/Adafruit_MAX31855.h
@@ -46,8 +46,8 @@ public:
   uint8_t readError();
 
 private:
-  Adafruit_SPIDevice spi_dev = NULL;
-  boolean initialized;
+  Adafruit_SPIDevice spi_dev;
+  bool initialized = false;
 
   uint32_t spiread32(void);
 };


### PR DESCRIPTION
Initialize `Adafruit_SPIDevice` in a initialisier list of `Adafruit_MAX31855`.

The `Adafruit_SPIDevice` objects are created when  the  `Adafruit_MAX31855` objects are created and initialized. Before that `spi_dev` does not need to have a value - even not `nullptr`.

All  `Adafruit_MAX31855` objects are created un-initialized - so init with `initialized = false`.

Remove unused variable `int i` in `spiread32()`

Fixing #41