### PR TITLE
Allow code to specify which SPI buss to use

### DIFF
--- a/Adafruit_MAX31855.cpp
+++ b/Adafruit_MAX31855.cpp
@@ -59,15 +59,6 @@ Adafruit_MAX31855::Adafruit_MAX31855(int8_t _sclk, int8_t _cs, int8_t _miso)
     @brief  Instantiates a new Adafruit_MAX31855 class using hardware SPI.
 
     @param _cs The pin to use for SPI Chip Select.
-*/
-/**************************************************************************/
-Adafruit_MAX31855::Adafruit_MAX31855(int8_t _cs) : spi_dev(_cs, 1000000) {}
-
-/**************************************************************************/
-/*!
-    @brief  Instantiates a new Adafruit_MAX31855 class using hardware SPI.
-
-    @param _cs The pin to use for SPI Chip Select.
     @param _spi which spi buss to use.
 */
 /**************************************************************************/

--- a/Adafruit_MAX31855.cpp
+++ b/Adafruit_MAX31855.cpp
@@ -65,6 +65,17 @@ Adafruit_MAX31855::Adafruit_MAX31855(int8_t _cs) : spi_dev(_cs, 1000000) {}
 
 /**************************************************************************/
 /*!
+    @brief  Instantiates a new Adafruit_MAX31855 class using hardware SPI.
+
+    @param _cs The pin to use for SPI Chip Select.
+    @param _spi which spi buss to use.
+*/
+/**************************************************************************/
+Adafruit_MAX31855::Adafruit_MAX31855(int8_t _cs, SPIClass *_spi)
+    : spi_dev(_cs, 1000000, SPI_BITORDER_MSBFIRST, SPI_MODE0, _spi) {}
+
+/**************************************************************************/
+/*!
     @brief  Setup the HW
 
     @return True if the device was successfully initialized, otherwise false.

--- a/Adafruit_MAX31855.h
+++ b/Adafruit_MAX31855.h
@@ -38,6 +38,7 @@ class Adafruit_MAX31855 {
 public:
   Adafruit_MAX31855(int8_t _sclk, int8_t _cs, int8_t _miso);
   Adafruit_MAX31855(int8_t _cs);
+  Adafruit_MAX31855(int8_t _cs, SPIClass *_spi);
 
   bool begin(void);
   double readInternal(void);

--- a/Adafruit_MAX31855.h
+++ b/Adafruit_MAX31855.h
@@ -37,8 +37,7 @@
 class Adafruit_MAX31855 {
 public:
   Adafruit_MAX31855(int8_t _sclk, int8_t _cs, int8_t _miso);
-  Adafruit_MAX31855(int8_t _cs);
-  Adafruit_MAX31855(int8_t _cs, SPIClass *_spi);
+  Adafruit_MAX31855(int8_t _cs, SPIClass *_spi = &SPI);
 
   bool begin(void);
   double readInternal(void);

--- a/examples/serialthermocouple/serialthermocouple.ino
+++ b/examples/serialthermocouple/serialthermocouple.ino
@@ -34,6 +34,11 @@ Adafruit_MAX31855 thermocouple(MAXCLK, MAXCS, MAXDO);
 //#define MAXCS   10
 //Adafruit_MAX31855 thermocouple(MAXCS);
 
+// Example creating a thermocouple instance with hardware SPI
+// on SPI1 using specified CS pin.
+//#define MAXCS   10
+//Adafruit_MAX31855 thermocouple(MAXCS, SPI1);
+
 void setup() {
   Serial.begin(9600);
 


### PR DESCRIPTION
As mentioned in issue #43,

A PJRC Forum member ran into an issue on using this library on a Teensy 4.1
He was trying to use SPI1 for this, but there was no way to tell the underlying spi_dev object to use SPI1, so I added an additional constructor.

Not sure if the SPI device would be best as first or last paremeter (I choose last)
and if better to pass by pointer or by reference.

```
  Adafruit_MAX31855(int8_t _cs, SPIClass *_spi);
```

It compiled for a Teensy, but have no hardware to test it with.

T