### PR TITLE
Add selective fault check control

### DIFF
--- a/Adafruit_MAX31855.cpp
+++ b/Adafruit_MAX31855.cpp
@@ -129,7 +129,7 @@ double Adafruit_MAX31855::readCelsius(void) {
   Serial.print("\tInternal Temp: "); Serial.println(internal);
   */
 
-  if (v & 0x7) {
+  if (v & faultMask) {
     // uh oh, a serious problem!
     return NAN;
   }
@@ -172,6 +172,21 @@ double Adafruit_MAX31855::readFahrenheit(void) {
   f /= 5.0;
   f += 32;
   return f;
+}
+
+/**************************************************************************/
+/*!
+    @brief  Set the faults to check when reading temperature. If any set
+    faults occur, temperature reading will return NAN.
+
+    @param faults Faults to check. Use logical OR combinations of preset
+    fault masks: MAX31855_FAULT_OPEN, MAX31855_FAULT_SHORT_GND,
+    MAX31855_FAULT_SHORT_VCC. Can also enable/disable all fault checks
+    using: MAX31855_FAULT_ALL or MAX31855_FAULT_NONE.
+*/
+/**************************************************************************/
+void Adafruit_MAX31855::setFaultChecks(uint8_t faults) {
+  faultMask = faults & 0x07;
 }
 
 /**************************************************************************/

--- a/Adafruit_MAX31855.h
+++ b/Adafruit_MAX31855.h
@@ -29,6 +29,12 @@
 
 #include <Adafruit_SPIDevice.h>
 
+#define MAX31855_FAULT_NONE (0x00)
+#define MAX31855_FAULT_OPEN (0x01)
+#define MAX31855_FAULT_SHORT_GND (0x02)
+#define MAX31855_FAULT_SHORT_VCC (0x04)
+#define MAX31855_FAULT_ALL (0x07)
+
 /**************************************************************************/
 /*!
     @brief  Sensor driver for the Adafruit MAX31855 thermocouple breakout.
@@ -44,11 +50,12 @@ public:
   double readCelsius(void);
   double readFahrenheit(void);
   uint8_t readError();
+  void setFaultChecks(uint8_t faults);
 
 private:
   Adafruit_SPIDevice spi_dev;
   bool initialized = false;
-
+  uint8_t faultMask = MAX31855_FAULT_ALL;
   uint32_t spiread32(void);
 };
 

--- a/Adafruit_MAX31855.h
+++ b/Adafruit_MAX31855.h
@@ -29,11 +29,11 @@
 
 #include <Adafruit_SPIDevice.h>
 
-#define MAX31855_FAULT_NONE (0x00)
-#define MAX31855_FAULT_OPEN (0x01)
-#define MAX31855_FAULT_SHORT_GND (0x02)
-#define MAX31855_FAULT_SHORT_VCC (0x04)
-#define MAX31855_FAULT_ALL (0x07)
+#define MAX31855_FAULT_NONE (0x00)      ///< Disable all fault checks
+#define MAX31855_FAULT_OPEN (0x01)      ///< Enable open circuit fault check
+#define MAX31855_FAULT_SHORT_GND (0x02) ///< Enable short to GND fault check
+#define MAX31855_FAULT_SHORT_VCC (0x04) ///< Enable short to VCC fault check
+#define MAX31855_FAULT_ALL (0x07)       ///< Enable all fault checks
 
 /**************************************************************************/
 /*!

--- a/examples/serialthermocouple/serialthermocouple.ino
+++ b/examples/serialthermocouple/serialthermocouple.ino
@@ -52,6 +52,10 @@ void setup() {
     Serial.println("ERROR.");
     while (1) delay(10);
   }
+
+  // OPTIONAL: Can configure fault checks as desired (default is ALL)
+  thermocouple.setFaultChecks(MAX31855_FAULT_OPEN);
+
   Serial.println("DONE.");
 }
 
@@ -62,7 +66,11 @@ void loop() {
 
    double c = thermocouple.readCelsius();
    if (isnan(c)) {
-     Serial.println("Something wrong with thermocouple!");
+     Serial.println("Thermocouple fault(s) detected!");
+     uint8_t e = thermocouple.readError();
+     if (e & MAX31855_FAULT_OPEN) Serial.println("FAULT: Thermocouple is open - no connections.");
+     if (e & MAX31855_FAULT_SHORT_GND) Serial.println("FAULT: Thermocouple is short-circuited to GND.");
+     if (e & MAX31855_FAULT_SHORT_VCC) Serial.println("FAULT: Thermocouple is short-circuited to VCC.");
    } else {
      Serial.print("C = ");
      Serial.println(c);

--- a/examples/serialthermocouple/serialthermocouple.ino
+++ b/examples/serialthermocouple/serialthermocouple.ino
@@ -27,12 +27,12 @@
 #define MAXCLK  5
 
 // initialize the Thermocouple
-Adafruit_MAX31855 thermocouple(MAXCLK, MAXCS, MAXDO);
+//Adafruit_MAX31855 thermocouple(MAXCLK, MAXCS, MAXDO);
 
 // Example creating a thermocouple instance with hardware SPI
 // on a given CS pin.
-//#define MAXCS   10
-//Adafruit_MAX31855 thermocouple(MAXCS);
+#define MAXCS   A0
+Adafruit_MAX31855 thermocouple(MAXCS);
 
 // Example creating a thermocouple instance with hardware SPI
 // on SPI1 using specified CS pin.
@@ -54,7 +54,8 @@ void setup() {
   }
 
   // OPTIONAL: Can configure fault checks as desired (default is ALL)
-  thermocouple.setFaultChecks(MAX31855_FAULT_OPEN);
+  // Multiple checks can be logically OR'd together.
+  // thermocouple.setFaultChecks(MAX31855_FAULT_OPEN | MAX31855_FAULT_SHORT_VCC);  // short to GND fault is ignored
 
   Serial.println("DONE.");
 }

--- a/examples/serialthermocouple/serialthermocouple.ino
+++ b/examples/serialthermocouple/serialthermocouple.ino
@@ -27,12 +27,12 @@
 #define MAXCLK  5
 
 // initialize the Thermocouple
-//Adafruit_MAX31855 thermocouple(MAXCLK, MAXCS, MAXDO);
+Adafruit_MAX31855 thermocouple(MAXCLK, MAXCS, MAXDO);
 
 // Example creating a thermocouple instance with hardware SPI
 // on a given CS pin.
-#define MAXCS   A0
-Adafruit_MAX31855 thermocouple(MAXCS);
+//#define MAXCS   10
+//Adafruit_MAX31855 thermocouple(MAXCS);
 
 // Example creating a thermocouple instance with hardware SPI
 // on SPI1 using specified CS pin.


### PR DESCRIPTION
This is a redo of PR #31.

It adds the ability to selectively enable/disable the various faults checks. Previously, the temperature reading would return NAN if *any* fault occurred. Now, faults can be selectively ignored (disabled) if desired, so that the temperature reading (correct or not) is returned.

One potentially useful application is as a work around for a phenomenon that can occur at high temperatures:
https://forums.adafruit.com/viewtopic.php?p=827564
This is essentially a false positive fault that is being reported, because physics. With this PR, one could knowingly disable that check so that the temperature reading would then be returned. And hopefully be valid.

Tested with updated example on QT PY M0.